### PR TITLE
Bugfix: After migrating to .NET 7.0, SendMessageAsync with an attachment threw an exception.

### DIFF
--- a/Anarchy/Anarchy.csproj
+++ b/Anarchy/Anarchy.csproj
@@ -13,8 +13,8 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <BaseOutputPath>..\.bin\$(MSBuildProjectName)</BaseOutputPath>
     <Description>The superior Discord API wrapper.</Description>
-    <Copyright>Copyright ©iLinked  2022</Copyright>
-    <VersionPrefix>0.8.3</VersionPrefix>
+    <Copyright>Copyright ©iLinked 2022</Copyright>
+    <VersionPrefix>0.8.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Anarchy/REST/HTTP/DiscordHttpClient.cs
+++ b/Anarchy/REST/HTTP/DiscordHttpClient.cs
@@ -156,7 +156,7 @@ namespace Discord
 
                 if (!string.IsNullOrEmpty(json))
                 {
-                    var jsonContent = new StringContent(json, null, null);
+                    var jsonContent = new StringContent(json);
                     jsonContent.Headers.Remove("Content-Type");
                     mpfc.Add(jsonContent, "\"payload_json\"");
                 }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 0.8.3.1
+### Improvements
+- Bugfix: .NET 7.0 verifies that StringContent ctor doesn't pass null arguments, which DiscordHttpClient (line 159) did.
+
+
+
 ## 0.8.3
 ### Improvements
 - Fixes #3330.


### PR DESCRIPTION
In .NET 7.0, System.Net.Http.StringContent does a better job validating its constructor's arguments and no longer accepts null arguments.